### PR TITLE
#48 bug fix for missing LOG_NO to cr_id transformation

### DIFF
--- a/invisible_flow/entities/data_allegation.py
+++ b/invisible_flow/entities/data_allegation.py
@@ -11,6 +11,7 @@ class Allegation:
     is_officer_complaint: bool
     location: str
     summary: str
+    cr_id: str
 
     def __iter__(self):
         return iter([
@@ -21,7 +22,8 @@ class Allegation:
             self.incident_date,
             self.is_officer_complaint,
             self.location,
-            self.summary
+            self.summary,
+            self.cr_id
         ])
 
     def to_array(self):
@@ -33,5 +35,6 @@ class Allegation:
             self.incident_date,
             self.is_officer_complaint,
             self.location,
-            self.summary
+            self.summary,
+            self.cr_id
         ]

--- a/invisible_flow/transformers/case_info_allegations_transformer.py
+++ b/invisible_flow/transformers/case_info_allegations_transformer.py
@@ -18,7 +18,8 @@ class CaseInfoAllegationsTransformer(TransformerBase):
             incident_date=str(df['COMPLAINT_DATE']),
             is_officer_complaint=str(df['COMPLAINANT_TYPE']) == 'CPD_EMPLOYEE',
             location=str(df['LOCATION_CODE']),
-            summary=""
+            summary="",
+            cr_id=str(df['LOG_NO'])
         )
 
     @staticmethod
@@ -37,8 +38,10 @@ class CaseInfoAllegationsTransformer(TransformerBase):
             'incident_date',
             'is_officer_complaint',
             'location',
-            'summary'
+            'summary',
+            'cr_id'
         ]
+
         return pd.DataFrame([allegation.to_array() for allegation in allegations], columns=column_names)
 
     @staticmethod

--- a/tests/entities/test_allegation.py
+++ b/tests/entities/test_allegation.py
@@ -11,7 +11,8 @@ class TestAllegation:
             incident_date='incident_date',
             is_officer_complaint=True,
             location='',
-            summary=''
+            summary='',
+            cr_id='1053951'
         )
         allegation_array = allegation.to_array()
         expected_array = [
@@ -22,6 +23,7 @@ class TestAllegation:
             'incident_date',
             True,
             '',
-            ''
+            '',
+            '1053951'
         ]
         assert expected_array == allegation_array

--- a/tests/helpers/resources/case_info_test_allegation_single_row.csv
+++ b/tests/helpers/resources/case_info_test_allegation_single_row.csv
@@ -1,2 +1,2 @@
-add1,add2,beat_id,city,incident_date,is_officer_complaint,location,summary
-1100,63RD ST,712,CHICAGO ILLINOIS 60621,11-MAY-12,False,COMMERCIAL / BUSINESS OFFICE,
+add1,add2,beat_id,city,incident_date,is_officer_complaint,location,summary,cr_id
+1100,63RD ST,712,CHICAGO ILLINOIS 60621,11-MAY-12,False,COMMERCIAL / BUSINESS OFFICE,,1053951

--- a/tests/transformers/test_caseInfoAllegationsTransformer.py
+++ b/tests/transformers/test_caseInfoAllegationsTransformer.py
@@ -26,7 +26,8 @@ class TestCaseInfoAllegationsTransformer(IFTestBase):
                 incident_date='11-MAY-12',
                 is_officer_complaint=False,
                 location='COMMERCIAL / BUSINESS OFFICE',
-                summary=''
+                summary='',
+                cr_id='1053951'
             )
             assert allegation_to_test == expected_allegation
             assert len(actual_allegations) == 9
@@ -40,7 +41,8 @@ class TestCaseInfoAllegationsTransformer(IFTestBase):
             incident_date='incident_date',
             is_officer_complaint=True,
             location='location',
-            summary='summary'
+            summary='summary',
+            cr_id='cr_id'
         )
         allegations = [a, a]
         df = CaseInfoAllegationsTransformer.transform_allegations_to_database_ready_df(allegations)
@@ -52,7 +54,8 @@ class TestCaseInfoAllegationsTransformer(IFTestBase):
             'incident_date',
             True,
             'location',
-            'summary'
+            'summary',
+            'cr_id'
         ], [
             'add1',
             'add2',
@@ -61,7 +64,9 @@ class TestCaseInfoAllegationsTransformer(IFTestBase):
             'incident_date',
             True,
             'location',
-            'summary'
+            'summary',
+            'cr_id'
+
         ]]
         column_names = [
             'add1',
@@ -71,7 +76,8 @@ class TestCaseInfoAllegationsTransformer(IFTestBase):
             'incident_date',
             'is_officer_complaint',
             'location',
-            'summary'
+            'summary',
+            'cr_id'
         ]
         expected_df = pd.DataFrame(source_arrays, columns=column_names)
         assert expected_df.equals(df)


### PR DESCRIPTION
added LOG_NO to cr_id transformation to allegation entity and transformer and updated tests accordingly.

output to cloud bucket:
<img width="836" alt="Screen Shot 2019-08-07 at 2 36 33 PM" src="https://user-images.githubusercontent.com/50185149/62661282-70dd7180-b925-11e9-8441-059ee87b7df5.png">
