### PR TITLE
Ignore GCS credentials in git - prevent tracking of secrets and exposure on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ htmlcov
 /examples/movies/movies.db
 *.orig
 CHANGELOG.temp
+googleCred.json


### PR DESCRIPTION
### Ignore GCS credentials in invisible flow project

**Problem**
It's necessary to use secret credentials in the invisible flow project, but as people roll on and off of the project, it may be difficult to communicate clearly the importance of keeping the GCS file out of the repository.

**Solution**
Add the file to gitignore, preventing the tracking of it in git.