### PR TITLE
[#84][Kyle] Improve loading strategy

### DIFF
--- a/invisible_flow/copa/loader.py
+++ b/invisible_flow/copa/loader.py
@@ -27,19 +27,6 @@ class Loader:
 
         db.session.close()
 
-    def original_load_strategy(self, transformed_data: pd.DataFrame):
-        self.existing_crid = pd.DataFrame(DataAllegation.query.with_entities(DataAllegation.cr_id)).values.flatten().tolist()
-
-        for row in transformed_data.itertuples():
-            if row.cr_id not in self.existing_crid:
-               new_allegation = DataAllegation(cr_id=row.cr_id)
-               db.session.add(new_allegation)
-               self.new_data.append(transformed_data.iloc[row[0]])
-            else:
-                self.matches.append(transformed_data.iloc[row[0]])
-
-        db.session.close()
-
     def get_matches(self):
         return self.matches
 

--- a/invisible_flow/copa/loader.py
+++ b/invisible_flow/copa/loader.py
@@ -27,6 +27,19 @@ class Loader:
 
         db.session.close()
 
+    def original_load_strategy(self, transformed_data: pd.DataFrame):
+        self.existing_crid = pd.DataFrame(DataAllegation.query.with_entities(DataAllegation.cr_id)).values.flatten().tolist()
+
+        for row in transformed_data.itertuples():
+            if row.cr_id not in self.existing_crid:
+               new_allegation = DataAllegation(cr_id=row.cr_id)
+               db.session.add(new_allegation)
+               self.new_data.append(transformed_data.iloc[row[0]])
+            else:
+                self.matches.append(transformed_data.iloc[row[0]])
+
+        db.session.close()
+
     def get_matches(self):
         return self.matches
 

--- a/invisible_flow/copa/loader.py
+++ b/invisible_flow/copa/loader.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from sqlalchemy.exc import IntegrityError
 
 from manage import db
 from invisible_flow.copa.data_allegation import DataAllegation
@@ -7,9 +8,6 @@ from invisible_flow.copa.data_allegation import DataAllegation
 class Loader:
 
     def __init__(self):
-        self.existing_crid = pd.DataFrame(
-            DataAllegation.query.with_entities(DataAllegation.cr_id)
-        ).values.flatten().tolist()
         self.matches = []
         self.new_data = []
 
@@ -17,14 +15,16 @@ class Loader:
 
         for row in transformed_data.itertuples():
 
-            if row.cr_id not in self.existing_crid:
-                new_allegation = DataAllegation(cr_id=row.cr_id)
-                db.session.add(new_allegation)
-                self.new_data.append(transformed_data.iloc[row[0]])
-            else:
+            new_allegation = DataAllegation(cr_id=row.cr_id)
+            db.session.add(new_allegation)
+            try:
+                db.session.commit()
+            except IntegrityError:
                 self.matches.append(transformed_data.iloc[row[0]])
+                db.session.rollback()
+            else:
+                self.new_data.append(transformed_data.iloc[row[0]])
 
-        db.session.commit()
         db.session.close()
 
     def get_matches(self):

--- a/invisible_flow/copa/loader.py
+++ b/invisible_flow/copa/loader.py
@@ -8,7 +8,7 @@ from invisible_flow.copa.data_allegation import DataAllegation
 class Loader:
 
     def __init__(self):
-        self.matches = []
+        self.existing_crids = []
         self.new_data = []
 
     def load_into_db(self, transformed_data: pd.DataFrame):
@@ -20,7 +20,7 @@ class Loader:
             try:
                 db.session.commit()
             except IntegrityError:
-                self.matches.append(transformed_data.iloc[row[0]])
+                self.existing_crids.append(transformed_data.iloc[row[0]])
                 db.session.rollback()
             else:
                 self.new_data.append(transformed_data.iloc[row[0]])
@@ -28,7 +28,7 @@ class Loader:
         db.session.close()
 
     def get_matches(self):
-        return self.matches
+        return self.existing_crids
 
     def get_new_data(self):
         return self.new_data

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+ignore_missing_imports = True
 
 [mypy-google.*]
 ignore_missing_imports = True

--- a/tests/copa/test_loader.py
+++ b/tests/copa/test_loader.py
@@ -52,6 +52,30 @@ class TestLoader:
         db.session.commit()
         db.session.close()
 
+    def test_benchmark_original_loading_strategy(self):
+        self.setup_db_with_mock_data_rows()
+
+        mysetup = '''
+from invisible_flow.copa.data_allegation import DataAllegation
+from invisible_flow.copa.data_allegation import insert_allegation_into_database
+from invisible_flow.copa.loader import Loader
+from tests.helpers.testing_data import transformed_data
+insert_allegation_into_database(DataAllegation(cr_id="1087378"))
+insert_allegation_into_database(DataAllegation(cr_id="1087387"))
+        '''
+
+        mycode = '''
+testLoader = Loader()
+testLoader.original_load_strategy(transformed_data)
+        '''
+        print("----------------Benchmark for original loading strategy:")
+        print(timeit.timeit(setup=mysetup, stmt=mycode, number=1000))
+
+        db.session.query(DataAllegation).delete()
+        # Clean up mock data rows
+
+        assert (False)
+
     def test_benchmark_new_loading_strategy(self):
         self.setup_db_with_mock_data_rows()
 

--- a/tests/copa/test_loader.py
+++ b/tests/copa/test_loader.py
@@ -6,7 +6,6 @@ from tests.helpers.testing_data import transformed_data
 from invisible_flow.copa.loader import Loader
 from invisible_flow.copa.data_allegation import DataAllegation
 from invisible_flow.copa.data_allegation import insert_allegation_into_database
-import timeit
 
 
 class TestLoader:
@@ -51,51 +50,3 @@ class TestLoader:
             db.session.add(new_allegation)
         db.session.commit()
         db.session.close()
-
-    def test_benchmark_original_loading_strategy(self):
-        self.setup_db_with_mock_data_rows()
-
-        mysetup = '''
-from invisible_flow.copa.data_allegation import DataAllegation
-from invisible_flow.copa.data_allegation import insert_allegation_into_database
-from invisible_flow.copa.loader import Loader
-from tests.helpers.testing_data import transformed_data
-insert_allegation_into_database(DataAllegation(cr_id="1087378"))
-insert_allegation_into_database(DataAllegation(cr_id="1087387"))
-        '''
-
-        mycode = '''
-testLoader = Loader()
-testLoader.original_load_strategy(transformed_data)
-        '''
-        print("----------------Benchmark for original loading strategy:")
-        print(timeit.timeit(setup=mysetup, stmt=mycode, number=1000))
-
-        db.session.query(DataAllegation).delete()
-        # Clean up mock data rows
-
-        assert (False)
-
-    def test_benchmark_new_loading_strategy(self):
-        self.setup_db_with_mock_data_rows()
-
-        mysetup = '''
-from invisible_flow.copa.data_allegation import DataAllegation
-from invisible_flow.copa.data_allegation import insert_allegation_into_database
-from invisible_flow.copa.loader import Loader
-from tests.helpers.testing_data import transformed_data
-insert_allegation_into_database(DataAllegation(cr_id="1087378"))
-insert_allegation_into_database(DataAllegation(cr_id="1087387"))
-        '''
-
-        mycode = '''
-testLoader = Loader()
-testLoader.load_into_db(transformed_data)
-        '''
-        print("----------------Benchmark for new loading strategy:")
-        print(timeit.timeit(setup=mysetup, stmt=mycode, number=1000))
-
-        db.session.query(DataAllegation).delete()
-        # Clean up mock data rows
-
-        assert(False)


### PR DESCRIPTION
**Increase efficiency of database loading**

**Context**
The `COPA` data being scraped contains a significant number of rows, and existing rows within our database must be checked for duplicates every time a scrape occurs. As the number of rows in the database grows, the efficiency of the loading strategy will be significant.

**Problem**
The current design of the loader has not taken into account the efficiency of the loader.

**Solution**
Use benchmark tests to compare solutions. See commits 3fc1106 and fba8524.