### PR TITLE
[#81][Kyle] Specify table to DataOfficerAllegation 

### DIFF
--- a/invisible_flow/copa/data_officer_allegation.py
+++ b/invisible_flow/copa/data_officer_allegation.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 class DataOfficerAllegation(db.Model):
     __bind_key__ = COPA_DB_BIND_KEY
+    __tablename__ = 'data_officerallegation'
     id = db.Column(db.Integer, primary_key=True)
     allegation_id = db.Column(db.String(30))
     allegation_category_id = db.Column(db.Integer)


### PR DESCRIPTION
### Align DataOfficerAllegation with cpdp database schema

**Problem**
SQLAlchemy converts a model name in camel case to a table name in snake case, in this instance `data_officer_allegation`. This does not match the name of the relevant table in the cpdp database schema.

**Solution**
Specify the table name manually in the model, as per the documentation here: https://docs.sqlalchemy.org/en/13/orm/extensions/declarative/table_config.html